### PR TITLE
fix description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Description: SeuratWrappers is a collection of community-provided methods and
 License: GPL-3 | file LICENSE
 Remotes: welch-lab/liger,
     hms-dbmi/conos,
-    immunogenomics/harmony,
     immunogenomics/presto,
     satijalab/seurat-data,
     velocyto-team/velocyto.R,
@@ -45,7 +44,8 @@ Imports:
     Seurat (>= 5.0.0),
     stats,
     utils,
-    rlang
+    rlang,
+    R.utils
 Collate:
     'internal.R'
     'alevin.R'


### PR DESCRIPTION
@dcollins15 @rsatija This adds `R.utils` to DESCRIPTION, which is listed in NAMESPACE. Also this removes `harmony` from remote, since `harmony`is available on CRAN. This wrong DESCRIPTION leads to installation failures,, especially when using reproducible environments with NixPkgs.
https://github.com/ropensci/rix/issues/390#issuecomment-2607175281

Thanks!